### PR TITLE
Fix the key deserializer mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ serde_bytes = "0.11"
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1.10.0", features = ["serde"] }

--- a/src/de/key_deserializer.rs
+++ b/src/de/key_deserializer.rs
@@ -182,7 +182,7 @@ where
 
     #[inline]
     fn is_human_readable(&self) -> bool {
-        false
+        true
     }
 }
 

--- a/src/ser/big_decimal_serializer.rs
+++ b/src/ser/big_decimal_serializer.rs
@@ -92,9 +92,9 @@ where
         unreachable!()
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         unreachable!()
     }
@@ -116,18 +116,18 @@ where
         unreachable!()
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         unreachable!()
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -135,7 +135,7 @@ where
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         unreachable!()
     }

--- a/src/ser/big_integer_serializer.rs
+++ b/src/ser/big_integer_serializer.rs
@@ -89,9 +89,9 @@ where
         unreachable!()
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         unreachable!()
     }
@@ -113,18 +113,18 @@ where
         unreachable!()
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         unreachable!()
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -132,7 +132,7 @@ where
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         unreachable!()
     }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -476,9 +476,9 @@ where
         self.serialize_unit()
     }
 
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
     where
-        T: Serialize,
+        T: Serialize + ?Sized,
     {
         value.serialize(self)
     }

--- a/src/test/maps.rs
+++ b/src/test/maps.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 use std::fmt::{self, Debug, Display};
 use std::hash::Hash;
 use std::iter::FromIterator;
+use uuid::Uuid;
 
 fn run_test<T>(key: T)
 where
@@ -100,4 +101,9 @@ impl Display for TestNewtype {
 #[test]
 fn newtype_keys() {
     run_test(TestNewtype("hello".to_string()))
+}
+
+#[test]
+fn uuid_keys() {
+    run_test(Uuid::nil())
 }


### PR DESCRIPTION
The serializer and deserializer were previously inconsistent, so things wouldn't round-trip properly if their format depends on the readability mode.