### PR TITLE
increase buffer size to support large smile file

### DIFF
--- a/src/de/string_cache.rs
+++ b/src/de/string_cache.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-const LIMIT: usize = 1024;
+const LIMIT: usize = 4096;
 
 pub struct StringCache<'de> {
     vec: Vec<Cow<'de, str>>,


### PR DESCRIPTION
I have a 14.4MB JSON file that can be encoded and decoded by the Java Jackson library without any issue. But when I use this crate to decode the smile file compressed by the Java Jackson library, it has always failed. At the end, simply increasing the "LIMIT" size solved the issue.
15M is a typical size for a JSON file I frequently encounter, and I hope this PR can be accepted.