### PR TITLE
fix(string_cache): Implement Jackson 2.18-compatible string cache beh…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,6 @@ memchr = "2"
 serde = "1"
 serde_bytes = "0.11"
 
-[workspace]
-
 [dev-dependencies]
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ memchr = "2"
 serde = "1"
 serde_bytes = "0.11"
 
+[workspace]
+
 [dev-dependencies]
 base64 = "0.22"
 serde = { version = "1", features = ["derive"] }

--- a/src/de/string_cache.rs
+++ b/src/de/string_cache.rs
@@ -10,7 +10,7 @@ pub struct StringCache<'de> {
 impl<'de> StringCache<'de> {
     pub fn new() -> Self {
         StringCache { 
-            vec: Vec::with_capacity(LIMIT),
+            vec: vec![],
             count: 0,
         }
     }
@@ -21,11 +21,7 @@ impl<'de> StringCache<'de> {
         if self.vec.len() >= LIMIT {
             // Cache is full - implement Jackson's exact wrap-around behavior
             let index = self.count % LIMIT;
-            if index < self.vec.len() {
-                self.vec[index] = s;
-            } else {
-                self.vec.push(s);
-            }
+            self.vec[index] = s;
             self.count += 1;
         } else {
             // Cache not full - normal append
@@ -36,5 +32,59 @@ impl<'de> StringCache<'de> {
 
     pub fn get(&self, reference: u16) -> Option<&Cow<'de, str>> {
         self.vec.get(reference as usize)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+
+    #[test]
+    fn test_wrap_around_behavior() {
+        let mut cache = StringCache::new();
+        
+        // Fill cache to limit
+        for i in 0..1024 {
+            cache.intern(Cow::Owned(format!("string_{}", i)));
+        }
+        
+        assert_eq!(cache.vec.len(), 1024);
+        assert_eq!(cache.count, 1024);
+        
+        // Verify first entry
+        if let Some(s) = cache.get(0) {
+            assert_eq!(s, "string_0");
+        }
+        
+        // Add more entries - should wrap around
+        cache.intern(Cow::Owned("new_string_0".to_string()));
+        
+        // Should still have 1024 entries
+        assert_eq!(cache.vec.len(), 1024);
+        assert_eq!(cache.count, 1025);
+        
+        // Index 0 should now contain the new string
+        if let Some(s) = cache.get(0) {
+            assert_eq!(s, "new_string_0");
+        }
+        
+        // Index 1 should still contain original
+        if let Some(s) = cache.get(1) {
+            assert_eq!(s, "string_1");
+        }
+        
+        // Add another - should overwrite index 1
+        cache.intern(Cow::Owned("new_string_1".to_string()));
+        
+        assert_eq!(cache.count, 1026);
+        if let Some(s) = cache.get(1) {
+            assert_eq!(s, "new_string_1");
+        }
+        
+        // Index 2 should still be original
+        if let Some(s) = cache.get(2) {
+            assert_eq!(s, "string_2");
+        }
     }
 }

--- a/src/de/string_cache.rs
+++ b/src/de/string_cache.rs
@@ -1,22 +1,37 @@
 use std::borrow::Cow;
 
-const LIMIT: usize = 1024;
+const LIMIT: usize = 1024; // Smile spec: maximum 1024 cached strings
 
 pub struct StringCache<'de> {
     vec: Vec<Cow<'de, str>>,
+    count: usize,  // Track insertion count for Jackson-compatible wrap-around
 }
 
 impl<'de> StringCache<'de> {
     pub fn new() -> Self {
-        StringCache { vec: vec![] }
+        StringCache { 
+            vec: Vec::with_capacity(LIMIT),
+            count: 0,
+        }
     }
 
     pub fn intern(&mut self, s: Cow<'de, str>) {
+        // Jackson exact behavior: when reaching LIMIT (1024), 
+        // wrap around and start overwriting from index 0
         if self.vec.len() >= LIMIT {
-            self.vec.clear();
+            // Cache is full - implement Jackson's exact wrap-around behavior
+            let index = self.count % LIMIT;
+            if index < self.vec.len() {
+                self.vec[index] = s;
+            } else {
+                self.vec.push(s);
+            }
+            self.count += 1;
+        } else {
+            // Cache not full - normal append
+            self.vec.push(s);
+            self.count = self.vec.len();
         }
-
-        self.vec.push(s);
     }
 
     pub fn get(&self, reference: u16) -> Option<&Cow<'de, str>> {

--- a/src/ser/string_cache.rs
+++ b/src/ser/string_cache.rs
@@ -5,22 +5,42 @@ const LIMIT: usize = 1024;
 
 pub struct StringCache {
     map: HashMap<Cow<'static, str>, u16>,
+    vec: Vec<Cow<'static, str>>,
+    count: usize,  // Track insertion count for Jackson-compatible wrap-around
 }
 
 impl StringCache {
     pub fn new() -> Self {
         StringCache {
             map: HashMap::new(),
+            vec: vec![],
+            count: 0,
         }
     }
 
     pub fn intern(&mut self, s: Cow<'static, str>) {
-        if self.map.len() >= LIMIT {
-            self.map.clear();
+        // Jackson exact behavior: when reaching LIMIT (1024), 
+        // wrap around and start overwriting from index 0
+        if self.vec.len() >= LIMIT {
+            // Cache is full - implement Jackson's exact wrap-around behavior
+            let index = self.count % LIMIT;
+            
+            // Remove old entry from map
+            if let Some(old_string) = self.vec.get(index) {
+                self.map.remove(old_string);
+            }
+            
+            // Replace with new entry
+            self.vec[index] = s.clone();
+            self.map.insert(s, index as u16);
+            self.count += 1;
+        } else {
+            // Cache not full - normal append
+            let id = self.vec.len() as u16;
+            self.vec.push(s.clone());
+            self.map.insert(s, id);
+            self.count = self.vec.len();
         }
-
-        let id = self.map.len() as u16;
-        self.map.insert(s, id);
     }
 
     pub fn get(&mut self, s: &str) -> Option<u16> {


### PR DESCRIPTION
## Problem
When parsing large files with Jackson 2.18-generated Smile data containing more than 1024 shared strings, serde-smile fails with "invalid string reference" errors. This happens because Jackson 2.18 and serde-smile handle cache overflow differently, leading to incompatible string reference mappings.

## Root Cause Analysis
**Jackson 2.18 behavior (SmileParser.java:605-612):**
```java
} else if (len == SmileConstants.MAX_SHARED_STRING_VALUES) { // too many? Just flush...
   newShared = oldShared;
   _seenStringValueCount = 0; // could also clear, but let's not yet bother
}
_seenStringValues[_seenStringValueCount++] = newText;
```

**Previous serde-smile behavior:**
```rust
if self.vec.len() >= LIMIT {
    self.vec.clear();  // Completely clears cache, breaking references
}
self.vec.push(s);
```

The key difference: Jackson resets the insertion counter but **preserves existing cache entries**, allowing old string references to remain valid. serde-smile cleared the entire cache, invalidating all existing references.

## Solution
Implement Jackson's exact cache overflow behavior:
- When cache reaches 1024 entries, wrap around and overwrite from index 0
- Track insertion count separately from cache size
- Preserve existing entries to maintain reference validity

## Specification Compliance
This change **violates the Smile specification** which states:
> "When the 1024-value buffer is full, it MUST clear out buffer and start from first entry"

However, it provides **compatibility with Jackson 2.18**, which is the de facto reference implementation used in production systems. The Jackson comment "could also clear, but let's not yet bother" indicates this was an intentional optimization that became widely adopted.

## Testing
Verified with 14MB+ files generated by applications using Jackson 2.18:
- Before: "invalid string reference" errors
- After: Successful parsing with correct field mappings

Fixes compatibility with Jackson 2.18-generated Smile data containing extensive shared string usage.

## Discussion

I'm not sure this "fix" should be managed as a feature in the crate and let the crate user choose to use this workaround or not.

🤖 Generated with [Claude Code](https://claude.ai/code)